### PR TITLE
fixed extensionless error

### DIFF
--- a/Part-4/part-4.py
+++ b/Part-4/part-4.py
@@ -535,8 +535,7 @@ class Main(QtGui.QMainWindow):
         if self.filename:
             
             # Append extension if not there yet
-            stri = str(self.filename)
-            if not stri.endswith(".writer"):
+            if not str(self.filename).endswith(".writer"):
               self.filename += ".writer"
 
             # We just store the contents of the text file along with the

--- a/Part-4/part-4.py
+++ b/Part-4/part-4.py
@@ -535,7 +535,8 @@ class Main(QtGui.QMainWindow):
         if self.filename:
             
             # Append extension if not there yet
-            if not self.filename.endswith(".writer"):
+            stri = str(self.filename)
+            if not stri.endswith(".writer"):
               self.filename += ".writer"
 
             # We just store the contents of the text file along with the


### PR DESCRIPTION
In the file ./Part-4/part-4.py. The if statement at line 535.
-----------------
        if self.filename:
            
            # Append extension if not there yet
            if not self.filename.endswith(".writer"):   self.filename += ".writer"

            # We just store the contents of the text file along with the
            # format in html, which Qt does in a very nice way for us
            with open(self.filename,"wt") as file:
                file.write(self.text.toHtml())

            self.changesSaved = True

should be modified to:
----------------------------------------------
        if self.filename:
            
            # Append extension if not there yet
            stri = str(self.filename)

            if not stri.endswith(".writer"):   self.filename += ".writer"

            # We just store the contents of the text file along with the
            # format in html, which Qt does in a very nice way for us
            with open(self.filename,"wt") as file:
                file.write(self.text.toHtml())

            self.changesSaved = True

so that the whenever a extension is not inputted. It takes .writer extension by default.
I have sent a pull request kindly merge.