### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/PyQt5/README.md
+++ b/PyQt5/README.md
@@ -3,7 +3,7 @@ PyQt5
 
 The changes between PyQt4 and Pyqt5 are rather manageable
 
-####QtGui
+#### QtGui
 PyQt4’s QtGui module has been split into PyQt5’s QtGui, QtPrintSupport and QtWidgets modules
 The Writer is using:
 
@@ -12,12 +12,12 @@ The Writer is using:
 + **QtPrintSupport:** QPrintPreviewDialog, QPrintDialog
 
 
-####QFileDialog
+#### QFileDialog
 
 **getOpenFileName()** and **getSaveFileName()** return a tuple (filename, filter) in PyQt5 instead of the filename as a string in PyQt4
 
 
 
-####More Infos
+#### More Infos
 The PyQT 5 Reference Guide has a list of all changes:
 http://pyqt.sourceforge.net/Docs/PyQt5/pyqt4_differences.html

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository holds the code for my tutorial series on __*Building a text edit
 + Inserting images
 + And more!
 
-##Tutorials
+## Tutorials
 
 Part 1: http://www.binpress.com/tutorial/building-a-text-editor-with-pyqt-part-one/143
 
@@ -22,10 +22,10 @@ Part 3: http://www.binpress.com/tutorial/building-a-text-editor-with-pyqt-part-3
 
 Part 4: http://www.binpress.com/tutorial/building-a-text-editor-with-pyqt-part-4/148
 
-##PyQt5
+## PyQt5
 
 Thanks to Jock2 the entire tutorial series is now ported to PyQt5 (see the PyQt5 folder).
 
-##Updates
+## Updates
 
 You can check for any updates or added features in the non-tutorial *Writer* repository, [here](https://github.com/goldsborough/Writer). After a certain accumulation of updates/features a new tutorial part may follow. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
